### PR TITLE
fix some errors

### DIFF
--- a/DHP19EPC/generate_DHP19/GetPoseLabels.m
+++ b/DHP19EPC/generate_DHP19/GetPoseLabels.m
@@ -1,19 +1,19 @@
 function [pose] = GetPoseLabels(XYZPOS, last_k, k, is_MeanLabel)
 pose = zeros(13, 3);
 if is_MeanLabel
-    pose(1,:) = nanmean(XYZPOS.XYZPOS.head(last_k:k,:),1);
-    pose(2,:) = nanmean(XYZPOS.XYZPOS.shoulderR(last_k:k,:),1);
-    pose(3,:) = nanmean(XYZPOS.XYZPOS.shoulderL(last_k:k,:),1);
-    pose(4,:) = nanmean(XYZPOS.XYZPOS.elbowR(last_k:k,:),1);
-    pose(5,:) = nanmean(XYZPOS.XYZPOS.elbowL(last_k:k,:),1);
-    pose(6,:) = nanmean(XYZPOS.XYZPOS.hipR(last_k:k,:),1);
-    pose(7,:) = nanmean(XYZPOS.XYZPOS.hipL(last_k:k,:),1);
-    pose(8,:) = nanmean(XYZPOS.XYZPOS.handR(last_k:k,:),1);
-    pose(9,:) = nanmean(XYZPOS.XYZPOS.handL(last_k:k,:),1);
-    pose(10,:) = nanmean(XYZPOS.XYZPOS.kneeR(last_k:k,:),1);
-    pose(11,:) = nanmean(XYZPOS.XYZPOS.kneeL(last_k:k,:),1);
-    pose(12,:) = nanmean(XYZPOS.XYZPOS.footR(last_k:k,:),1);
-    pose(13,:) = nanmean(XYZPOS.XYZPOS.footL(last_k:k,:),1);
+    pose(1,:) = mean(XYZPOS.XYZPOS.head(last_k:k,:),1,'omitnan');
+    pose(2,:) = mean(XYZPOS.XYZPOS.shoulderR(last_k:k,:),1,'omitnan');
+    pose(3,:) = mean(XYZPOS.XYZPOS.shoulderL(last_k:k,:),1,'omitnan');
+    pose(4,:) = mean(XYZPOS.XYZPOS.elbowR(last_k:k,:),1,'omitnan');
+    pose(5,:) = mean(XYZPOS.XYZPOS.elbowL(last_k:k,:),1,'omitnan');
+    pose(6,:) = mean(XYZPOS.XYZPOS.hipR(last_k:k,:),1,'omitnan');
+    pose(7,:) = mean(XYZPOS.XYZPOS.hipL(last_k:k,:),1,'omitnan');
+    pose(8,:) = mean(XYZPOS.XYZPOS.handR(last_k:k,:),1,'omitnan');
+    pose(9,:) = mean(XYZPOS.XYZPOS.handL(last_k:k,:),1,'omitnan');
+    pose(10,:) = mean(XYZPOS.XYZPOS.kneeR(last_k:k,:),1,'omitnan');
+    pose(11,:) = mean(XYZPOS.XYZPOS.kneeL(last_k:k,:),1,'omitnan');
+    pose(12,:) = mean(XYZPOS.XYZPOS.footR(last_k:k,:),1,'omitnan');
+    pose(13,:) = mean(XYZPOS.XYZPOS.footL(last_k:k,:),1,'omitnan');
 else
     pose(1,:) = XYZPOS.XYZPOS.head(k,:);
     pose(2,:) = XYZPOS.XYZPOS.shoulderR(k,:);

--- a/evaluate/eval_args_tools.py
+++ b/evaluate/eval_args_tools.py
@@ -6,6 +6,7 @@ import argparse
 import torch
 import sys
 import torch.cuda
+sys.path.append("../")
 from models import Pose_PointNet, Pose_DGCNN, Pose_PointTransformer
 
 


### PR DESCRIPTION
The following errors have been corrected.

- [Function 'nanmean' (input argument of type 'single') is undefined. #4](https://github.com/MasterHow/EventPointPose/issues/4)

- Cannot import classes in `models` directory when running `python evaluate/evaluate.py` to evaluate it.
  ```sh
  Traceback (most recent call last):
    File "F:\EventPointPose\evaluate\evaluate.py", line 7, in <module>
      from eval_run_tools import init_point_model
    File "F:\EventPointPose\evaluate\eval_run_tools.py", line 15, in <module>
      from eval_args_tools import point_args_init, point_model_init
    File "F:\EventPointPose\evaluate\eval_args_tools.py", line 10, in <module>        
      from models import Pose_PointNet, Pose_DGCNN, Pose_PointTransformer
  ModuleNotFoundError: No module named 'models'
  ```

